### PR TITLE
Fix publishing CI: update RcppParallel to 6.2.0 to match P3M's rebuilt rstan binary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,6 @@ jobs:
         env:
           RENV_CONFIG_REPOS_OVERRIDE: ${{ env.RSPM }}
           RENV_CONFIG_PAK_ENABLED: "FALSE"
-          RENV_CONFIG_INSTALL_FROM_SOURCE: "TRUE"
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/renv.lock
+++ b/renv.lock
@@ -236,30 +236,29 @@
     },
     "RcppParallel": {
       "Package": "RcppParallel",
-      "Version": "5.1.11-1",
+      "Version": "6.2.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Parallel Programming Tools for 'Rcpp'",
-      "Authors@R": "c( person(\"JJ\", \"Allaire\", role = c(\"aut\"), email = \"jj@rstudio.com\"), person(\"Romain\", \"Francois\", role = c(\"aut\", \"cph\")), person(\"Kevin\", \"Ushey\", role = c(\"aut\", \"cre\"), email = \"kevin@rstudio.com\"), person(\"Gregory\", \"Vandenbrouck\", role = \"aut\"), person(\"Marcus\", \"Geelnard\", role = c(\"aut\", \"cph\"), comment = \"TinyThread library, https://tinythreadpp.bitsnbites.eu/\"), person(\"Hamada S.\", \"Badr\", email = \"badr@jhu.edu\", role = c(\"ctb\"), comment = c(ORCID = \"0000-0002-9808-2344\")), person(family = \"Posit, PBC\", role = \"cph\"), person(family = \"Intel\", role = c(\"aut\", \"cph\"), comment = \"Intel TBB library, https://www.threadingbuildingblocks.org/\"), person(family = \"Microsoft\", role = \"cph\") )",
+      "Authors@R": "c( person(\"Kevin\", \"Ushey\", role = c(\"aut\", \"cre\"), email = \"kevin@rstudio.com\", comment = c(ORCID = \"0000-0003-2880-7407\")), person(\"JJ\", \"Allaire\", role = c(\"aut\"), email = \"jj@rstudio.com\"), person(\"Romain\", \"Francois\", role = c(\"aut\", \"cph\")), person(\"Gregory\", \"Vandenbrouck\", role = \"aut\"), person(\"Marcus\", \"Geelnard\", role = c(\"aut\", \"cph\"), comment = \"TinyThread library, https://tinythreadpp.bitsnbites.eu/\"), person(\"Hamada S.\", \"Badr\", email = \"badr@jhu.edu\", role = c(\"ctb\"), comment = c(ORCID = \"0000-0002-9808-2344\")), person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\"), email = \"edd@debian.org\", comment = c(ORCID = \"0000-0001-6419-907X\")), person(family = \"Intel\", role = c(\"aut\", \"cph\"), comment = \"oneTBB library\"), person(family = \"UXL Foundation\", role = c(\"aut\", \"cph\"), comment = \"oneTBB library\"), person(family = \"Microsoft\", role = \"cph\"), person(family = \"Posit, PBC\", role = \"cph\") )",
       "Description": "High level functions for parallel programming with 'Rcpp'. For example, the 'parallelFor()' function can be used to convert the work of a standard serial \"for\" loop into a parallel one and the 'parallelReduce()' function can be used for accumulating aggregate or other values.",
       "Depends": [
-        "R (>= 3.0.2)"
+        "R (>= 3.6.0)"
       ],
       "Suggests": [
         "Rcpp",
-        "RUnit",
         "knitr",
         "rmarkdown"
       ],
-      "SystemRequirements": "GNU make, Intel TBB, Windows: cmd.exe and cscript.exe, Solaris: g++ is required",
+      "SystemRequirements": "CMake (>= 3.5)",
       "License": "GPL (>= 3)",
       "URL": "https://rcppcore.github.io/RcppParallel/, https://github.com/RcppCore/RcppParallel",
       "BugReports": "https://github.com/RcppCore/RcppParallel/issues",
       "Biarch": "TRUE",
-      "RoxygenNote": "7.1.1",
+      "RoxygenNote": "7.3.3",
       "Encoding": "UTF-8",
       "NeedsCompilation": "yes",
-      "Author": "JJ Allaire [aut], Romain Francois [aut, cph], Kevin Ushey [aut, cre], Gregory Vandenbrouck [aut], Marcus Geelnard [aut, cph] (TinyThread library, https://tinythreadpp.bitsnbites.eu/), Hamada S. Badr [ctb] (ORCID: <https://orcid.org/0000-0002-9808-2344>), Posit, PBC [cph], Intel [aut, cph] (Intel TBB library, https://www.threadingbuildingblocks.org/), Microsoft [cph]",
+      "Author": "Kevin Ushey [aut, cre] (ORCID: <https://orcid.org/0000-0003-2880-7407>), JJ Allaire [aut], Romain Francois [aut, cph], Gregory Vandenbrouck [aut], Marcus Geelnard [aut, cph] (TinyThread library, https://tinythreadpp.bitsnbites.eu/), Hamada S. Badr [ctb] (ORCID: <https://orcid.org/0000-0002-9808-2344>), Dirk Eddelbuettel [aut] (ORCID: <https://orcid.org/0000-0001-6419-907X>), Intel [aut, cph] (oneTBB library), UXL Foundation [aut, cph] (oneTBB library), Microsoft [cph], Posit, PBC [cph]",
       "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
       "Repository": "CRAN"
     },


### PR DESCRIPTION
## Root cause (verified by binary inspection, not guesswork)

CI has been red since late July with:

```
unable to load shared object '.../rstan/libs/rstan.so':
undefined symbol: _ZN3tbb6detail2r17observeERNS0_2d123task_scheduler_observerEb
```

That symbol demangles to `tbb::detail::r1::observe(tbb::detail::d1::task_scheduler_observer&, bool)` — the **new oneTBB 2021+ ABI**. I downloaded the actual binaries the failing runs installed and inspected them:

| Artifact | Built | TBB linkage |
|---|---|---|
| `rstan 2.32.7` P3M jammy binary | **2026-07-31 06:41** | no `DT_NEEDED` on libtbb; expects TBB symbols pre-loaded by RcppParallel; references `tbb::detail::r1::observe` (oneTBB) |
| `RcppParallel 6.2.0` P3M binary | **2026-07-31 06:32** | bundles oneTBB as `libtbb.so.2` — **exports** that symbol |
| `RcppParallel 5.1.11-1` archived binary (what the lockfile pins) | 2025 | bundles old TBB 2019 — only exports `tbb::internal::task_scheduler_observer_v3::observe(bool)` |

RcppParallel 6.2.0 (a major release that switched the bundled TBB from the 2019 ABI to oneTBB) hit CRAN on July 30. Posit Package Manager then **rebuilt its rstan 2.32.7 binary against it** (9 minutes apart on the same builder). Since `renv.lock` still pinned RcppParallel **5.1.11-1**, renv restored a new-ABI rstan next to an old-ABI RcppParallel, and rstan's post-install load test failed. Nothing in this repo changed — the same lockfile passed on June 9 and the breakage window matches the P3M rebuild exactly. The failure was identical on `ubuntu-latest` (noble) and the `ubuntu-22.04` pin, because it never depended on system TBB at all — rstan resolves TBB from the library RcppParallel loads globally, not from the system.

### Why the attempts in #33 couldn't work

- `use-public-rspm` now **defaults to `true`** in `r-lib/actions/setup-r@v2`, so deleting the line changed nothing — the action still exported `RENV_CONFIG_REPOS_OVERRIDE` pointing at P3M.
- P3M `__linux__` URLs serve **binaries through the source-package API**, so `options(pkgType = "source")`, `.Rprofile` hacks, and `RENV_CONFIG_INSTALL_FROM_SOURCE` (which isn't a real renv option) can never force source builds from those URLs.

## The fix

- **`renv.lock`**: bump RcppParallel `5.1.11-1` → `6.2.0`. This restores ABI coherence with the binaries P3M now serves; I verified by symbol table cross-check that RcppParallel 6.2.0's bundled `libtbb.so.2` satisfies every undefined TBB symbol in the rebuilt `rstan.so`.
- **`publish.yml`**: drop the no-op `RENV_CONFIG_INSTALL_FROM_SOURCE` line. Everything else (jammy pin, `use-public-rspm: true`, system deps) is left untouched.

## Notes

- **Local environments**: after pulling this, `renv::restore()` will update RcppParallel to 6.2.0 locally. If your locally installed rstan binary predates the CRAN/P3M rebuild, it may hit the mirror-image mismatch — fix with `renv::rebuild("rstan")` or a fresh `install.packages("rstan")`.
- **Future robustness**: this class of breakage (P3M `latest` rebuilding binaries against deps newer than the lockfile pins) can be eliminated entirely by pointing `RENV_CONFIG_REPOS_OVERRIDE` at a dated P3M snapshot that matches the lockfile, at the cost of bumping the date when you update packages. Happy to do that as a follow-up if you want it.
- Supersedes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011duGnALX3QxoPjapELj9cj

---
_Generated by [Claude Code](https://claude.ai/code/session_011duGnALX3QxoPjapELj9cj)_