### PR TITLE
Fix broken bmm link in navbar to https://venpopov.com/bmm/

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -34,8 +34,8 @@ website:
         text: CV
       - text: R Packages
         menu:
-          - href: https://venpopov.github.io/bmm/index.html
-            text: bmm (Bayesian Measurement Modeling
+          - href: https://venpopov.com/bmm/
+            text: bmm (Bayesian Measurement Modeling)
           - href: https://venpopov.github.io/chkptstanr/index.html
             text: chkptstanr (Checkpointing for Stan)
       - href: posts/index.qmd


### PR DESCRIPTION
Also close the missing parenthesis in the menu label.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011pMBzefaX3dnDXDWw2nPeU
