### PR TITLE
Fix broken bmm link in navbar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -34,8 +34,8 @@ website:
         text: CV
       - text: R Packages
         menu:
-          - href: https://venpopov.github.io/bmm/index.html
-            text: bmm (Bayesian Measurement Modeling
+          - href: https://venpopov.com/bmm/
+            text: bmm (Bayesian Measurement Modeling)
           - href: https://venpopov.github.io/chkptstanr/index.html
             text: chkptstanr (Checkpointing for Stan)
       - href: posts/index.qmd


### PR DESCRIPTION
The navbar's R Packages menu pointed to https://venpopov.github.io/bmm/index.html, which now returns 404. Updated it to https://venpopov.com/bmm/ (verified 200), and closed the missing parenthesis in the menu label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pMBzefaX3dnDXDWw2nPeU